### PR TITLE
Removed Duplication in ObjectiveClass

### DIFF
--- a/ObjectiveKit.xcodeproj/project.pbxproj
+++ b/ObjectiveKit.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		344C27861DD5CDCF008AA223 /* ObjectiveKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 344C27781DD5CDCF008AA223 /* ObjectiveKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		344C27901DD5CFAB008AA223 /* ObjectiveClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 344C278F1DD5CFAB008AA223 /* ObjectiveClass.swift */; };
 		344C27941DD6F4E1008AA223 /* RuntimeClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 344C27931DD6F4E1008AA223 /* RuntimeClass.swift */; };
+		D7D1F6F71E4BAE4200C6E22E /* Optional+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7D1F6F61E4BAE4200C6E22E /* Optional+Extensions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -35,6 +36,7 @@
 		344C27851DD5CDCF008AA223 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		344C278F1DD5CFAB008AA223 /* ObjectiveClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjectiveClass.swift; sourceTree = "<group>"; };
 		344C27931DD6F4E1008AA223 /* RuntimeClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RuntimeClass.swift; sourceTree = "<group>"; };
+		D7D1F6F61E4BAE4200C6E22E /* Optional+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Optional+Extensions.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -82,6 +84,7 @@
 				344C27931DD6F4E1008AA223 /* RuntimeClass.swift */,
 				344553051DDA6C1B007852A1 /* RuntimeModification.swift */,
 				344C27791DD5CDCF008AA223 /* Info.plist */,
+				D7D1F6F61E4BAE4200C6E22E /* Optional+Extensions.swift */,
 			);
 			path = ObjectiveKit;
 			sourceTree = "<group>";
@@ -174,6 +177,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 344C276B1DD5CDCF008AA223;
 			productRefGroup = 344C27761DD5CDCF008AA223 /* Products */;
@@ -209,6 +213,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				344C27901DD5CFAB008AA223 /* ObjectiveClass.swift in Sources */,
+				D7D1F6F71E4BAE4200C6E22E /* Optional+Extensions.swift in Sources */,
 				344553061DDA6C1B007852A1 /* RuntimeModification.swift in Sources */,
 				344C27941DD6F4E1008AA223 /* RuntimeClass.swift in Sources */,
 			);

--- a/ObjectiveKit/ObjectiveClass.swift
+++ b/ObjectiveKit/ObjectiveClass.swift
@@ -57,10 +57,13 @@ public class ObjectiveClass <T: NSObject>: ObjectiveKitRuntimeModification {
         return self.runtimeStrings(with: { class_copyPropertyList($0, $1) }, transform: property_getName)
     }
     
+    // MARK: Private
+    
     private func runtimeEntities<Type, Result>(
         with copyingGetter: RuntimeCopyingGetter<Type>,
         transform: (Type) -> Result?
-    ) -> [Result]
+    )
+        -> [Result]
     {
         var cCount: CUnsignedInt = 0
         
@@ -69,14 +72,19 @@ public class ObjectiveClass <T: NSObject>: ObjectiveKitRuntimeModification {
         
         defer { entities?.deallocate(capacity: count) }
         
-        return UnsafeMutableBufferPointer(start: entities, count: count).flatMap(identity).flatMap(transform)
+        return UnsafeMutableBufferPointer(start: entities, count: count)
+            .flatMap(identity)
+            .flatMap(transform)
     }
     
     private func runtimeStrings<Type>(
         with copyingGetter: RuntimeCopyingGetter<Type>,
         transform: (Type!) -> UnsafePointer<Int8>!
-    ) -> [String]
+    )
+        -> [String]
     {
-        return self.runtimeEntities(with: copyingGetter) { pure(transform($0)).map { String(cString: $0) } }
+        return self.runtimeEntities(with: copyingGetter) {
+            pure(transform($0)).map(String.init(cString:))
+        }
     }
 }

--- a/ObjectiveKit/ObjectiveClass.swift
+++ b/ObjectiveKit/ObjectiveClass.swift
@@ -43,8 +43,8 @@ public class ObjectiveClass <T: NSObject>: ObjectiveKitRuntimeModification {
     /// - Returns: An array of protocol names.
     public var protocols: [String] {
         return self.runtimeStrings(
-            with: { (cls, count) -> UnsafeMutablePointer<Protocol?>! in
-                let raw = UnsafeRawPointer(class_copyProtocolList(cls, count))
+            with: {
+                let raw = UnsafeRawPointer(class_copyProtocolList($0, $1))
                 let unsafeProtocols = raw?.assumingMemoryBound(to: (Protocol?).self)
                 
                 return UnsafeMutablePointer(mutating: unsafeProtocols)

--- a/ObjectiveKit/ObjectiveClass.swift
+++ b/ObjectiveKit/ObjectiveClass.swift
@@ -59,8 +59,9 @@ public class ObjectiveClass <T: NSObject>: ObjectiveKitRuntimeModification {
         return self.runtimeStrings(with: { class_copyPropertyList($0, $1) }, transform: property_getName)
     }
     
+    private typealias RuntimeCopyingGetter<Type> = (AnyClass?, UnsafeMutablePointer<UInt32>?) -> UnsafeMutablePointer<Type?>!
     private func runtimeEntities<Type, Result>(
-        with copyingGetter:(AnyClass?, UnsafeMutablePointer<UInt32>?) -> UnsafeMutablePointer<Type?>!,
+        with copyingGetter: RuntimeCopyingGetter<Type>,
         transform: (Type) -> Result?
     ) -> [Result]
     {
@@ -76,7 +77,7 @@ public class ObjectiveClass <T: NSObject>: ObjectiveKitRuntimeModification {
     }
     
     private func runtimeStrings<Type>(
-        with copyingGetter:(AnyClass?, UnsafeMutablePointer<UInt32>?) -> UnsafeMutablePointer<Type?>!,
+        with copyingGetter:RuntimeCopyingGetter<Type>,
         transform: (Type!) -> UnsafePointer<Int8>!
     ) -> [String]
     {

--- a/ObjectiveKit/Optional+Extensions.swift
+++ b/ObjectiveKit/Optional+Extensions.swift
@@ -1,0 +1,17 @@
+//
+//  Optional+Extensions.swift
+//  ObjectiveKit
+//
+//  Created by Oleksa 'trimm' Korin on 2/8/17.
+//  Copyright © 2017 Roy Marmelstein. All rights reserved.
+//
+
+/// Wraps value in optional
+public func pure<T>(_ value: T) -> T? {
+    return value
+}
+
+/// Returns the value passed as the parameter
+public func identity<T>(_ value: T) -> T {
+    return value
+}


### PR DESCRIPTION
The code was created for the sole purpose of showing my students, that they should think on their own instead of following thought leaders and popular bloggers, as they, while being popular, still are human and sometimes don't write that great or just plain bad and dirty code. The code prior to the pull request is a perfect example of such code because of the excess amount of duplication.

The secondary aim of refactoring was to show my students, how to use some unobvious ways of handling functions in swift, when using unsafe force-cast related code.

I've created this pull request just to check, how hacktoberfest (I really want that t-shirt, yay) reacts to rejected or ignored pull requests, as original maintainer, from what it looks, ignores pull requests from other users.

P.S. I doubt the maintainer would merge the pull request, so I didn't update to Swift 4. If accept happens for some weird reason, I would refactor it to swift 4 with pleasure.
