### PR TITLE
Swift5

### DIFF
--- a/ObjectiveKit.xcodeproj/project.pbxproj
+++ b/ObjectiveKit.xcodeproj/project.pbxproj
@@ -72,10 +72,11 @@
 		344C276B1DD5CDCF008AA223 = {
 			isa = PBXGroup;
 			children = (
+				B4F33973249F2DA90054DFE5 /* Frameworks */,
 				344C27771DD5CDCF008AA223 /* ObjectiveKit */,
 				344C27821DD5CDCF008AA223 /* ObjectiveKitTests */,
 				344C27761DD5CDCF008AA223 /* Products */,
-				B4F33973249F2DA90054DFE5 /* Frameworks */,
+				B4F33977249F5F9A0054DFE5 /* Supporting Files */,
 			);
 			sourceTree = "<group>";
 		};
@@ -129,11 +130,7 @@
 		B4F33967249F0DCF0054DFE5 /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
-				B4F3396B249F2BB60054DFE5 /* build.sh */,
 				344C27791DD5CDCF008AA223 /* Info.plist */,
-				B4F3396D249F2BC30054DFE5 /* LICENSE */,
-				B4F3396F249F2BD10054DFE5 /* ObjectiveKit.podspec */,
-				B4F33971249F2BDF0054DFE5 /* README.md */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";
@@ -152,6 +149,17 @@
 				B4F33974249F2DA90054DFE5 /* MapKit.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		B4F33977249F5F9A0054DFE5 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				B4F3396B249F2BB60054DFE5 /* build.sh */,
+				B4F3396D249F2BC30054DFE5 /* LICENSE */,
+				B4F3396F249F2BD10054DFE5 /* ObjectiveKit.podspec */,
+				B4F33971249F2BDF0054DFE5 /* README.md */,
+			);
+			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */

--- a/ObjectiveKit.xcodeproj/project.pbxproj
+++ b/ObjectiveKit.xcodeproj/project.pbxproj
@@ -13,6 +13,12 @@
 		344C27861DD5CDCF008AA223 /* ObjectiveKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 344C27781DD5CDCF008AA223 /* ObjectiveKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		344C27901DD5CFAB008AA223 /* ObjectiveClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 344C278F1DD5CFAB008AA223 /* ObjectiveClass.swift */; };
 		344C27941DD6F4E1008AA223 /* RuntimeClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 344C27931DD6F4E1008AA223 /* RuntimeClass.swift */; };
+		B4F3396A249F169A0054DFE5 /* NSObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F33969249F169A0054DFE5 /* NSObject.swift */; };
+		B4F3396C249F2BB60054DFE5 /* build.sh in Resources */ = {isa = PBXBuildFile; fileRef = B4F3396B249F2BB60054DFE5 /* build.sh */; };
+		B4F3396E249F2BC30054DFE5 /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = B4F3396D249F2BC30054DFE5 /* LICENSE */; };
+		B4F33970249F2BD10054DFE5 /* ObjectiveKit.podspec in Resources */ = {isa = PBXBuildFile; fileRef = B4F3396F249F2BD10054DFE5 /* ObjectiveKit.podspec */; };
+		B4F33972249F2BDF0054DFE5 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = B4F33971249F2BDF0054DFE5 /* README.md */; };
+		B4F33976249F2EE70054DFE5 /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B4F33974249F2DA90054DFE5 /* MapKit.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -35,6 +41,12 @@
 		344C27851DD5CDCF008AA223 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		344C278F1DD5CFAB008AA223 /* ObjectiveClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjectiveClass.swift; sourceTree = "<group>"; };
 		344C27931DD6F4E1008AA223 /* RuntimeClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RuntimeClass.swift; sourceTree = "<group>"; };
+		B4F33969249F169A0054DFE5 /* NSObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSObject.swift; sourceTree = "<group>"; };
+		B4F3396B249F2BB60054DFE5 /* build.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = build.sh; sourceTree = SOURCE_ROOT; };
+		B4F3396D249F2BC30054DFE5 /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = SOURCE_ROOT; };
+		B4F3396F249F2BD10054DFE5 /* ObjectiveKit.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; path = ObjectiveKit.podspec; sourceTree = SOURCE_ROOT; };
+		B4F33971249F2BDF0054DFE5 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = SOURCE_ROOT; };
+		B4F33974249F2DA90054DFE5 /* MapKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MapKit.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/MapKit.framework; sourceTree = DEVELOPER_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -42,6 +54,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B4F33976249F2EE70054DFE5 /* MapKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -62,6 +75,7 @@
 				344C27771DD5CDCF008AA223 /* ObjectiveKit */,
 				344C27821DD5CDCF008AA223 /* ObjectiveKitTests */,
 				344C27761DD5CDCF008AA223 /* Products */,
+				B4F33973249F2DA90054DFE5 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -77,11 +91,12 @@
 		344C27771DD5CDCF008AA223 /* ObjectiveKit */ = {
 			isa = PBXGroup;
 			children = (
-				344C27781DD5CDCF008AA223 /* ObjectiveKit.h */,
+				B4F33965249F0D110054DFE5 /* Extensions */,
 				344C278F1DD5CFAB008AA223 /* ObjectiveClass.swift */,
+				344C27781DD5CDCF008AA223 /* ObjectiveKit.h */,
+				B4F33966249F0D250054DFE5 /* Protocols */,
 				344C27931DD6F4E1008AA223 /* RuntimeClass.swift */,
-				344553051DDA6C1B007852A1 /* RuntimeModification.swift */,
-				344C27791DD5CDCF008AA223 /* Info.plist */,
+				B4F33967249F0DCF0054DFE5 /* Supporting Files */,
 			);
 			path = ObjectiveKit;
 			sourceTree = "<group>";
@@ -90,9 +105,53 @@
 			isa = PBXGroup;
 			children = (
 				344C27831DD5CDCF008AA223 /* ObjectiveKitTests.swift */,
-				344C27851DD5CDCF008AA223 /* Info.plist */,
+				B4F33968249F0DD70054DFE5 /* Supporting Files */,
 			);
 			path = ObjectiveKitTests;
+			sourceTree = "<group>";
+		};
+		B4F33965249F0D110054DFE5 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				B4F33969249F169A0054DFE5 /* NSObject.swift */,
+			);
+			name = Extensions;
+			sourceTree = "<group>";
+		};
+		B4F33966249F0D250054DFE5 /* Protocols */ = {
+			isa = PBXGroup;
+			children = (
+				344553051DDA6C1B007852A1 /* RuntimeModification.swift */,
+			);
+			name = Protocols;
+			sourceTree = "<group>";
+		};
+		B4F33967249F0DCF0054DFE5 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				B4F3396B249F2BB60054DFE5 /* build.sh */,
+				344C27791DD5CDCF008AA223 /* Info.plist */,
+				B4F3396D249F2BC30054DFE5 /* LICENSE */,
+				B4F3396F249F2BD10054DFE5 /* ObjectiveKit.podspec */,
+				B4F33971249F2BDF0054DFE5 /* README.md */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		B4F33968249F0DD70054DFE5 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				344C27851DD5CDCF008AA223 /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		B4F33973249F2DA90054DFE5 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				B4F33974249F2DA90054DFE5 /* MapKit.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -152,28 +211,29 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0810;
-				LastUpgradeCheck = 0810;
+				LastUpgradeCheck = 1150;
 				ORGANIZATIONNAME = "Roy Marmelstein";
 				TargetAttributes = {
 					344C27741DD5CDCF008AA223 = {
 						CreatedOnToolsVersion = 8.1;
-						DevelopmentTeam = 62DRUND7HT;
+						DevelopmentTeam = PJWXCWS5U5;
 						LastSwiftMigration = 0810;
 						ProvisioningStyle = Automatic;
 					};
 					344C277D1DD5CDCF008AA223 = {
 						CreatedOnToolsVersion = 8.1;
-						DevelopmentTeam = 62DRUND7HT;
+						DevelopmentTeam = PJWXCWS5U5;
 						ProvisioningStyle = Automatic;
 					};
 				};
 			};
 			buildConfigurationList = 344C276F1DD5CDCF008AA223 /* Build configuration list for PBXProject "ObjectiveKit" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 344C276B1DD5CDCF008AA223;
 			productRefGroup = 344C27761DD5CDCF008AA223 /* Products */;
@@ -191,6 +251,10 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B4F33970249F2BD10054DFE5 /* ObjectiveKit.podspec in Resources */,
+				B4F3396E249F2BC30054DFE5 /* LICENSE in Resources */,
+				B4F33972249F2BDF0054DFE5 /* README.md in Resources */,
+				B4F3396C249F2BB60054DFE5 /* build.sh in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -209,6 +273,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				344C27901DD5CFAB008AA223 /* ObjectiveClass.swift in Sources */,
+				B4F3396A249F169A0054DFE5 /* NSObject.swift in Sources */,
 				344553061DDA6C1B007852A1 /* RuntimeModification.swift in Sources */,
 				344C27941DD6F4E1008AA223 /* RuntimeClass.swift in Sources */,
 			);
@@ -237,20 +302,30 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -260,6 +335,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -274,12 +350,14 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -290,20 +368,30 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -313,6 +401,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -321,10 +410,12 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -337,8 +428,9 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 62DRUND7HT;
+				DEVELOPMENT_TEAM = PJWXCWS5U5;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 3;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -350,7 +442,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -359,8 +451,9 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 62DRUND7HT;
+				DEVELOPMENT_TEAM = PJWXCWS5U5;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 3;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -371,7 +464,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.roymarmelstein.ObjectiveKit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -379,12 +472,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				DEVELOPMENT_TEAM = 62DRUND7HT;
+				DEVELOPMENT_TEAM = PJWXCWS5U5;
 				INFOPLIST_FILE = ObjectiveKitTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.roymarmelstein.ObjectiveKitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -392,12 +485,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				DEVELOPMENT_TEAM = 62DRUND7HT;
+				DEVELOPMENT_TEAM = PJWXCWS5U5;
 				INFOPLIST_FILE = ObjectiveKitTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.roymarmelstein.ObjectiveKitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/ObjectiveKit.xcodeproj/xcshareddata/xcschemes/ObjectiveKit.xcscheme
+++ b/ObjectiveKit.xcodeproj/xcshareddata/xcschemes/ObjectiveKit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0810"
+   LastUpgradeVersion = "1150"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "344C27741DD5CDCF008AA223"
+            BuildableName = "ObjectiveKit.framework"
+            BlueprintName = "ObjectiveKit"
+            ReferencedContainer = "container:ObjectiveKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,17 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "344C27741DD5CDCF008AA223"
-            BuildableName = "ObjectiveKit.framework"
-            BlueprintName = "ObjectiveKit"
-            ReferencedContainer = "container:ObjectiveKit.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -70,8 +68,6 @@
             ReferencedContainer = "container:ObjectiveKit.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/ObjectiveKit.xcodeproj/xcshareddata/xcschemes/ObjectiveKitTests.xcscheme
+++ b/ObjectiveKit.xcodeproj/xcshareddata/xcschemes/ObjectiveKitTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0810"
+   LastUpgradeVersion = "1150"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -23,8 +23,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -36,8 +34,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/ObjectiveKit/NSObject.swift
+++ b/ObjectiveKit/NSObject.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/**
+ - Migrator: ISHIKAWA Koutarou
+ - Migrated from Swift 3 to Swift 5: 2020/06/19
+ - Migrate Copyright: © 2020 ISHIKAWA Koutarou. All rights reserved.
+ - Original Created: 2016/11/14
+ - Original Copyright: © 2016 Roy Marmelstein All rights reserved. This software is licensed under the MIT License. Full details can be found in the README.
+ */
+public extension NSObject {
+	
+	/// A convenience method to perform selectors by identifier strings.
+	/// - Parameter identifier: Selector name.
+	func performMethod(_ identifier: String) {
+		perform(NSSelectorFromString(identifier))
+	}
+}

--- a/ObjectiveKit/ObjectiveClass.swift
+++ b/ObjectiveKit/ObjectiveClass.swift
@@ -1,39 +1,39 @@
-//
-//  UnregisteredClass.swift
-//  ObjectiveKit
-//
-//  Created by Roy Marmelstein on 11/11/2016.
-//  Copyright © 2016 Roy Marmelstein. All rights reserved.
-//
-
 import Foundation
 
-typealias ImplementationBlock = @convention(block) () -> Void
+//typealias ImplementationBlock = @convention(block) () -> Void
 
-/// An object that allows you to introspect and modify classes through the ObjC runtime.
+/**
+ An object that allows you to introspect and modify classes through the ObjC runtime.
+ - Migrator: ISHIKAWA Koutarou
+ - Migrated from Swift 3 to Swift 5: 2020/06/19
+ - Migrate Copyright: © 2020 ISHIKAWA Koutarou. All rights reserved.
+ - Original Author: Roy Marmelstein
+ - Original Created: 2016/11/11
+ - Original Copyright: © 2016 Roy Marmelstein All rights reserved. This software is licensed under the MIT License. Full details can be found in the README.
+ */
 public class ObjectiveClass <T: NSObject>: ObjectiveKitRuntimeModification {
 
     public var internalClass: AnyClass
 
-    // MARK: Lifecycle
+
+	//MARK: - Lifecycle
 
     /// Init
     public init() {
         self.internalClass = T.classForCoder()
     }
 
-    // MARK: Introspection
 
-    /// Get all instance variables implemented by the class.
-    ///
-    /// - Returns: An array of instance variables.
+	//MARK: - Introspection
+
+    /// All instance variables implemented by the class.
     public var ivars: [String] {
         get {
             var count: CUnsignedInt = 0
             var ivars = [String]()
-            let ivarList = class_copyIvarList(internalClass, &count)
+            let ivarList = class_copyIvarList(self.internalClass, &count)
             for i in (0..<Int(count)) {
-                let unwrapped  = ivarList?[i].unsafelyUnwrapped
+                let unwrapped: Ivar  = ivarList![i].self
                 if let ivar = ivar_getName(unwrapped) {
                     let string = String(cString: ivar)
                     ivars.append(string)
@@ -44,65 +44,75 @@ public class ObjectiveClass <T: NSObject>: ObjectiveKitRuntimeModification {
         }
     }
 
-
-    /// Get all selectors implemented by the class.
-    ///
-    /// - Returns: An array of selectors.
+    /// All selectors implemented by the class.
     public var selectors: [Selector]  {
         get {
             var count: CUnsignedInt = 0
             var selectors = [Selector]()
-            let methodList = class_copyMethodList(internalClass, &count)
+            let methodList = class_copyMethodList(self.internalClass, &count)
             for i in (0..<Int(count)) {
-                let unwrapped  = methodList?[i].unsafelyUnwrapped
-                if let selector = method_getName(unwrapped) {
-                    selectors.append(selector)
-                }
+                let unwrapped: Method  = methodList![i].self
+				selectors.append(method_getName(unwrapped))
             }
             free(methodList)
             return selectors
         }
     }
 
-    /// Get all protocols implemented by the class.
-    ///
-    /// - Returns: An array of protocol names.
+    /// All protocols implemented by the class.
     public var protocols: [String] {
         get {
             var count: CUnsignedInt = 0
             var protocols = [String]()
-            let protocolList = class_copyProtocolList(internalClass, &count)
+            let protocolList = class_copyProtocolList(self.internalClass, &count)
             for i in (0..<Int(count)) {
-                let unwrapped  = protocolList?[i].unsafelyUnwrapped
-                if let protocolName = protocol_getName(unwrapped) {
-                    let string = String(cString: protocolName)
-                    protocols.append(string)
-                }
+                let unwrapped: Protocol  = protocolList![i].self
+				let string: String = String.init(cString: protocol_getName(unwrapped))
+				protocols.append(string)
             }
             return protocols
         }
     }
 
-    /// Get all properties implemented by the class.
-    ///
-    /// - Returns: An array of property names.
+    /// All properties implemented by the class.
     public var properties: [String] {
         get {
             var count: CUnsignedInt = 0
             var properties = [String]()
-            let propertyList = class_copyPropertyList(internalClass, &count)
+            let propertyList = class_copyPropertyList(self.internalClass, &count)
             for i in (0..<Int(count)) {
-                let unwrapped  = propertyList?[i].unsafelyUnwrapped
-                if let propretyName = property_getName(unwrapped) {
-                    let string = String(cString: propretyName)
-                    properties.append(string)
-                }
+                let unwrapped: objc_property_t  = propertyList![i].self
+				let string: String = String.init(cString: property_getName(unwrapped))
+				properties.append(string)
             }
             free(propertyList)
             return properties
         }
     }
 
+
+	//MARK: - ObjectiveKitRuntimeModification (Runtime modification)
+
+	public func addSelector(_ selector: Selector, from originalClass: AnyClass) {
+		guard let method: Method = class_getInstanceMethod(originalClass, selector), let typeEncoding: UnsafePointer<Int8> = method_getTypeEncoding(method) else {
+			return
+		}
+		let implementation: IMP = method_getImplementation(method)
+		let string: String = String.init(cString: typeEncoding)
+		class_addMethod(self.internalClass, selector, implementation, string)
+	}
+
+	public func addMethod(_ identifier: String, implementation: @escaping @convention(block) () -> Void) {
+		let blockObject: AnyObject = unsafeBitCast(implementation, to: AnyObject.self)
+		let implementation: IMP = imp_implementationWithBlock(blockObject)
+		let selector: Selector = NSSelectorFromString(identifier)
+		let encoding: String = "v@:f"
+		class_addMethod(self.internalClass, selector, implementation, encoding)
+	}
+
+	public func exchangeSelector(_ aSelector: Selector, with otherSelector: Selector) {
+		let method: Method? = class_getInstanceMethod(self.internalClass, aSelector)
+		let otherMethod: Method? = class_getInstanceMethod(self.internalClass, otherSelector)
+		method_exchangeImplementations(method!, otherMethod!)
+	}
 }
-
-

--- a/ObjectiveKit/RuntimeClass.swift
+++ b/ObjectiveKit/RuntimeClass.swift
@@ -1,39 +1,38 @@
-//
-//  RuntimeClass.swift
-//  ObjectiveKit
-//
-//  Created by Roy Marmelstein on 12/11/2016.
-//  Copyright © 2016 Roy Marmelstein. All rights reserved.
-//
-
 import Foundation
 
-/// A class created at runtime.
+/**
+ A class created at runtime.
+ - Migrator: ISHIKAWA Koutarou
+ - Migrated from Swift 3 to Swift 5: 2020/06/19
+ - Migrate Copyright: © 2020 ISHIKAWA Koutarou. All rights reserved.
+ - Original Created: 2016/11/12
+ - Original Copyright: © 2016 Roy Marmelstein All rights reserved. This software is licensed under the MIT License. Full details can be found in the README.
+ */
 public class RuntimeClass: NSObject, ObjectiveKitRuntimeModification {
 
     public var internalClass: AnyClass
 
     private var registered: Bool = false
 
-    // MARK: Lifecycle
+
+	//MARK: - Lifecycle
 
     /// Init
-    ///
     /// - Parameter superclass: Superclass to inherit from.
     public init(superclass: AnyClass = NSObject.classForCoder()) {
         let name = NSUUID().uuidString
-        self.internalClass = objc_allocateClassPair(superclass, name, 0)
+		self.internalClass = objc_allocateClassPair(superclass, name, 0)!
     }
 
-    // MARK: Dynamic class creation
+
+	//MARK: - Dynamic class creation
 
     /// Add ivar to the newly created class. You can only add ivars before a class is registered.
-    ///
     /// - Parameters:
     ///   - name: Ivar name.
     ///   - type: Ivar type.
     public func addIvar(_ name: String, type: ObjectiveType) {
-        assert(registered == false, "You can only add ivars before a class is registered")
+		assert(self.registered == false, "You can only add ivars before a class is registered")
         let rawEncoding = type.encoding()
         var size: Int = 0
         var alignment: Int = 0
@@ -44,20 +43,44 @@ public class RuntimeClass: NSObject, ObjectiveKitRuntimeModification {
 
     /// Register class. Required before usage. Happens automatically on allocate.
     public func register() {
-        if registered == false {
-            registered =  true
-            objc_registerClassPair(internalClass)
+        if self.registered == false {
+            self.registered =  true
+            objc_registerClassPair(self.internalClass)
         }
     }
 
     /// Allocate an instance of a new custom class at runtime.
-    ///
     /// - Returns: Custom class object.
     public func allocate() -> NSObject {
         self.register()
-        return internalClass.alloc() as! NSObject
+        return self.internalClass.alloc() as! NSObject
     }
 
+
+	//MARK: - ObjectiveKitRuntimeModification (Runtime modification)
+
+	public func addSelector(_ selector: Selector, from originalClass: AnyClass) {
+		guard let method: Method = class_getInstanceMethod(originalClass, selector), let typeEncoding: UnsafePointer<Int8> = method_getTypeEncoding(method) else {
+			return
+		}
+		let implementation: IMP = method_getImplementation(method)
+		let string: String = String.init(cString: typeEncoding)
+		class_addMethod(self.internalClass, selector, implementation, string)
+	}
+
+	public func addMethod(_ identifier: String, implementation: @escaping @convention(block) () -> Void) {
+		let blockObject: AnyObject = unsafeBitCast(implementation, to: AnyObject.self)
+		let implementation: IMP = imp_implementationWithBlock(blockObject)
+		let selector: Selector = NSSelectorFromString(identifier)
+		let encoding: String = "v@:f"
+		class_addMethod(self.internalClass, selector, implementation, encoding)
+	}
+
+	public func exchangeSelector(_ aSelector: Selector, with otherSelector: Selector) {
+		let method: Method? = class_getInstanceMethod(self.internalClass, aSelector)
+		let otherMethod: Method? = class_getInstanceMethod(self.internalClass, otherSelector)
+		method_exchangeImplementations(method!, otherMethod!)
+	}
 }
 
 
@@ -89,4 +112,3 @@ public enum ObjectiveType: Int {
     }
 
 }
-

--- a/ObjectiveKit/RuntimeModification.swift
+++ b/ObjectiveKit/RuntimeModification.swift
@@ -1,75 +1,35 @@
-//
-//  RuntimeModification.swift
-//  ObjectiveKit
-//
-//  Created by Roy Marmelstein on 14/11/2016.
-//  Copyright © 2016 Roy Marmelstein. All rights reserved.
-//
-
 import Foundation
 
+/**
+ - Migrator: ISHIKAWA Koutarou
+ - Migrated from Swift 3 to Swift 5: 2020/06/19
+ - Migrate Copyright: © 2020 ISHIKAWA Koutarou. All rights reserved.
+ - Original Created: 2016/11/14
+ - Original Copyright: © 2016 Roy Marmelstein All rights reserved. This software is licensed under the MIT License. Full details can be found in the README.
+ */
 public protocol ObjectiveKitRuntimeModification {
 
     var internalClass: AnyClass { get }
 
-    // MARK: Runtime modification
+
+	//MARK: - Runtime modification
 
     /// Add a selector that is implemented on another object to the current class.
-    ///
     /// - Parameters:
     ///   - selector: Selector.
     ///   - originalClass: Object implementing the selector.
     func addSelector(_ selector: Selector, from originalClass: AnyClass)
 
     /// Add a custom method to the current class.
-    ///
     /// - Parameters:
     ///   - identifier: Selector name.
     ///   - implementation: Implementation as a closure.
-    func addMethod(_ identifier: String, implementation: ImplementationBlock)
+    func addMethod(_ identifier: String, implementation: @escaping @convention(block) () -> Void)
 
     /// Exchange selectors implemented in the current class.
-    ///
     /// - Parameters:
     ///   - aSelector: Selector.
     ///   - otherSelector: Selector.
     func exchangeSelector(_ aSelector: Selector, with otherSelector: Selector)
 
 }
-
-extension ObjectiveKitRuntimeModification {
-
-    public func addSelector(_ selector: Selector, from originalClass: AnyClass) {
-        guard let method = class_getInstanceMethod(originalClass, selector), let implementation = method_getImplementation(method), let typeEncoding = method_getTypeEncoding(method) else {
-            return
-        }
-        let string = String(cString: typeEncoding)
-        class_addMethod(internalClass, selector, implementation, string)
-    }
-
-    public func addMethod(_ identifier: String, implementation: ImplementationBlock) {
-        let blockObject = unsafeBitCast(implementation, to: AnyObject.self)
-        let implementation = imp_implementationWithBlock(blockObject)
-        let selector = NSSelectorFromString(identifier)
-        let encoding = "v@:f"
-        class_addMethod(internalClass, selector, implementation, encoding)
-    }
-
-    public func exchangeSelector(_ aSelector: Selector, with otherSelector: Selector) {
-        let method = class_getInstanceMethod(internalClass, aSelector)
-        let otherMethod = class_getInstanceMethod(internalClass, otherSelector)
-        method_exchangeImplementations(method, otherMethod)
-    }
-
-}
-
-public extension NSObject {
-
-    /// A convenience method to perform selectors by identifier strings.
-    ///
-    /// - Parameter identifier: Selector name.
-    public func performMethod(_ identifier: String) {
-        perform(NSSelectorFromString(identifier))
-    }
-}
-

--- a/ObjectiveKitTests/ObjectiveKitTests.swift
+++ b/ObjectiveKitTests/ObjectiveKitTests.swift
@@ -1,15 +1,14 @@
-//
-//  ObjectiveKitTests.swift
-//  ObjectiveKitTests
-//
-//  Created by Roy Marmelstein on 11/11/2016.
-//  Copyright © 2016 Roy Marmelstein. All rights reserved.
-//
-
 import XCTest
 import MapKit
 @testable import ObjectiveKit
 
+/**
+ - Migrator: ISHIKAWA Koutarou
+ - Migrated from Swift 3 to Swift 5: 2020/06/19
+ - Migrate Copyright: © 2020 ISHIKAWA Koutarou. All rights reserved.
+ - Original Created: 2016/11/11
+ - Original Copyright: © 2016 Roy Marmelstein All rights reserved. This software is licensed under the MIT License. Full details can be found in the README.
+ */
 @objc class Subview: UIView {
 
     dynamic func testSelector() {
@@ -22,6 +21,13 @@ import MapKit
 
 }
 
+/**
+ - Migrator: ISHIKAWA Koutarou
+ - Migrated from Swift 3 to Swift 5: 2020/06/19
+ - Migrate Copyright: © 2020 ISHIKAWA Koutarou. All rights reserved.
+ - Original Created: 2016/11/11
+ - Original Copyright: © 2016 Roy Marmelstein All rights reserved. This software is licensed under the MIT License. Full details can be found in the README.
+ */
 @objc class ObjectiveKitTests: XCTestCase {
 
     let closureName = "random"
@@ -32,42 +38,51 @@ import MapKit
 
     func testAddClosure() {
         let methodExpectation = expectation(description: "Method was called")
-        let objectiveView = ObjectiveClass<UIView>()
-        objectiveView.addMethod(closureName, implementation: {
+
+		let objectiveView: ObjectiveClass<UIView> = ObjectiveClass<UIView>()
+        objectiveView.addMethod(self.closureName, implementation: {
             methodExpectation.fulfill()
         })
-        let view = UIView()
-        view.performMethod(closureName)
+
+		let view: UIView = UIView()
+        view.performMethod(self.closureName)
         waitForExpectations(timeout: 0.1, handler:nil)
     }
 
     func testAddSelector() {
-        let view = UIView()
-        XCTAssertFalse(view.responds(to: #selector(testSelector)))
-        let objectiveView = ObjectiveClass<UIView>()
-        objectiveView.addSelector(#selector(testSelector), from: self.classForCoder)
-        XCTAssert(view.responds(to: #selector(testSelector)))
+        let view: UIView = UIView()
+
+		XCTAssertFalse(view.responds(to: #selector(self.testSelector)))
+
+		let objectiveView: ObjectiveClass<UIView> = ObjectiveClass<UIView>()
+        objectiveView.addSelector(#selector(self.testSelector), from: self.classForCoder)
+
+		XCTAssert(view.responds(to: #selector(self.testSelector)))
     }
 
     func testRuntimeClass() {
-        let runtimeClass = RuntimeClass()
-        runtimeClass.addIvar("test", type: .Float)
-        let runtimeObject = runtimeClass.allocate()
+        let runtimeClass: RuntimeClass = RuntimeClass()
+        runtimeClass.addIvar("test", type: ObjectiveType.Float)
+
+		let runtimeObject: NSObject = runtimeClass.allocate()
         runtimeObject.setValue(4.0, forKey: "test")
-        XCTAssert(runtimeObject.value(forKey: "test") as? Float == 4.0)
+
+		XCTAssert(runtimeObject.value(forKey: "test") as? Float == 4.0)
     }
 
     func testIntrospection() {
-        let objectiveView = ObjectiveClass<MKMapView>()
-        let ivars = objectiveView.ivars
+        let objectiveView: ObjectiveClass<MKMapView> = ObjectiveClass<MKMapView>()
+
+		let ivars: Array<String> = objectiveView.ivars
         XCTAssert(ivars.contains("_camera"))
-        let selectors = objectiveView.selectors
+
+		let selectors: Array<Selector> = objectiveView.selectors
         XCTAssert(selectors.contains(NSSelectorFromString("layoutSubviews")))
-        let protocols = objectiveView.protocols
+
+		let protocols: Array<String> = objectiveView.protocols
         XCTAssert(protocols.contains("MKAnnotationManagerDelegate"))
-        let properties = objectiveView.properties
+
+		let properties: Array<String> = objectiveView.properties
         XCTAssert(properties.contains("mapRegion"))
     }
-
-
 }


### PR DESCRIPTION
Nice to meet you.
I am Koutarou Ishikawa, Japanese application engineer.
I am trying to do a "programming-shakyo" on the framework `PXSourceList`: porting it from Objective-C to Swift.

When I compiled "ObjectiveKit" with Xcode 11, there were some errors in it. So I fixed it.

- Changes list:
  - Swift version: from 3 to 5.

  - The location of definition `performMethod(_:)`: Moved from RuntimeModification.swift to NSObject.swift.
    NSObject.swift into added group 'Extensions', without Folder.
    RuntimeModification.swift into added group 'Protocols', without Folder.

  - Changed the implementation location of the following methods to ObjectiveClass and RuntimeClass: `addSelector(_:from:)`, `addMethod(_:implementation:)`, and `exchangeSelector(_:implementation:)`.

  - The parameter `implementation` of `addMethod(_:implementation:)`: correctted from `ImplementationBlock` to `@escaping @convention(block) () -> Void`.

  - The sources of variable `unwrapped` in `ivars`, `selectors`, `protocols`, and `properties` on ObjectiveClass: correctted from `ivarList?[i].unsafelyUnwrapped` to `propertyList![i].self`.

  - Moved `build.sh`, `LICENSE`, `ObjectiveKit.podspec`, `README.md` into added group 'Supporting Files', without Folder.

  - Since only calling MapKit in the Test class, added the MapKit.framework to the target "ObjectiveKit".
  However, I personally think not correct that adding MapKit.framework to ObjectiveKit.xcodeproj in order to pass 'testIntrospection()'.
